### PR TITLE
Persist theme across pages

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,9 @@
+// Apply saved theme on load
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'dark') {
+  document.body.classList.add('dark');
+}
+
 // ========= Typing Effect with Pause =========
 const texts = ["ISLAMIC SCHOLAR", "EDUCATOR", "WRITER", "IT-SKILLED", "DEVELOPER"];
 let count = 0;
@@ -23,9 +29,11 @@ let letter = '';
 
 // ========= Theme Toggle =========
 const toggleBtn = document.getElementById('theme-toggle');
+toggleBtn.textContent = document.body.classList.contains('dark') ? '☀️' : '🌙';
 toggleBtn.addEventListener('click', () => {
   document.body.classList.toggle('dark');
   toggleBtn.textContent = document.body.classList.contains('dark') ? '☀️' : '🌙';
+  localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
 });
 
 // ========= Burger Menu =========

--- a/thankyou.html
+++ b/thankyou.html
@@ -78,7 +78,7 @@
   <a href="index.html" class="btn">← Go Back to Portfolio</a>
 
   <script>
-    // Optional: Enable dark mode if body has .dark (from localStorage)
+    // Apply saved theme for cross-page consistency
     if (localStorage.getItem('theme') === 'dark') {
       document.body.classList.add('dark');
     }


### PR DESCRIPTION
## Summary
- Load saved theme from `localStorage` on page init
- Toggle and persist theme preference when switching modes
- Keep thank-you page in sync by applying stored theme

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b47bee11d08331be9504ab0a890c3e