### PR TITLE
Fix translation path for i18n assets

### DIFF
--- a/script.js
+++ b/script.js
@@ -275,7 +275,7 @@ arabicBtn.addEventListener('click', () => {
 
 // (1) সহায়ক: data-i18n থাকা সব নোড আপডেট করা
 async function applyTranslationsFrom(lang){
-  const url = `/i18n/${lang}.json`;
+  const url = `i18n/${lang}.json`;
   let dict = {};
   try {
     const res = await fetch(url, { cache: 'no-cache' });


### PR DESCRIPTION
## Summary
- fix translation loader path by using a relative URL

## Testing
- `npm test` (fails: ENOENT, package.json missing)
- `curl -s http://localhost:8000/i18n/ar.json`


------
https://chatgpt.com/codex/tasks/task_b_68b9d0079c8c83319f2871e3f3062ae5