### PR TITLE
Add translations for CV download buttons

### DIFF
--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -46,7 +46,7 @@
   "contact.message": "رسالتك",
 
   "cv.title": "اختر لغة السيرة الذاتية",
-  "cv.downloadEn": "Download English CV",
+  "cv.downloadEn": "تحميل السيرة الذاتية بالإنجليزية",
   "cv.downloadAr": "تحميل السيرة الذاتية بالعربية",
 
   "footer.copy": "© 2025 أشِق إلاهي. جميع الحقوق محفوظة. | البريد:"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,53 @@
+{
+  "nav.home": "Home",
+  "nav.about": "About",
+  "nav.experience": "Experience",
+  "nav.education": "Education",
+  "nav.skills": "Skills",
+  "nav.works": "Projects",
+  "nav.contact": "Contact",
+
+  "hero.greet": "Assalamu Alaikum, I'm",
+  "btn.explore": "Explore My Work",
+  "btn.downloadCv": "Download CV",
+
+  "section.about": "About Me",
+  "section.experience": "Experience",
+  "section.education": "Education",
+  "section.skills": "Skills",
+  "section.projects": "Projects",
+  "section.contact": "Contact Me",
+  "section.languages": "Languages",
+  "section.certs": "Certificates & Training",
+
+  "card.quran.title": "Quran Recitation",
+  "card.quran.desc": "Listen to melodious recitations.",
+  "card.hadith.title": "Hadith Collection",
+  "card.hadith.desc": "Selected Hadiths with Bangla translation and explanation.",
+  "card.dua.title": "Daily Du'as",
+  "card.dua.desc": "Important daily prayers with translation.",
+  "card.web.title": "Web Projects",
+  "card.web.desc": "Modern, responsive websites using HTML & CSS.",
+  "card.poster.title": "Poster Designs",
+  "card.poster.desc": "Islamic poster design using Illustrator & Photoshop.",
+  "card.data.title": "Data Management",
+  "card.data.desc": "Managed academic, financial, and student data with digital accuracy.",
+
+  "btn.listen": "Listen Now",
+  "btn.exploreGeneric": "Explore",
+  "btn.learn": "Learn More",
+  "btn.viewProjects": "View Projects",
+  "btn.viewDesigns": "View Designs",
+  "btn.dataDetails": "See Details",
+  "btn.sendMessage": "Send Message",
+
+  "contact.name": "Your Name",
+  "contact.email": "Your Email",
+  "contact.message": "Your Message",
+
+  "cv.title": "Select CV Language",
+  "cv.downloadEn": "Download English CV",
+  "cv.downloadAr": "Download Arabic CV",
+
+  "footer.copy": "© 2025 Ashiq Elahi. All rights reserved. | Email:"
+}

--- a/index.html
+++ b/index.html
@@ -307,8 +307,8 @@
         <div class="cv-modal-content">
             <span class="close-modal">&times;</span>
             <h2 data-i18n="cv.title">Select CV Language</h2>
-            <button id="downloadEnglish" class="btn">Download English CV</button>
-            <button id="downloadArabic" class="btn">تحميل السيرة الذاتية بالعربية</button>
+            <button id="downloadEnglish" class="btn" data-i18n="cv.downloadEn">Download English CV</button>
+            <button id="downloadArabic" class="btn" data-i18n="cv.downloadAr">Download Arabic CV</button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Enable i18n for CV download buttons with new data attributes
- Provide English translation file and update Arabic strings

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_b_68b9d124fb7483318de1fd89fbca9e64