### PR TITLE
Persist theme selection across pages

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,9 @@
+// Apply saved theme on page load
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'dark') {
+  document.body.classList.add('dark');
+}
+
 /* ===== Typing Effect (multilingual) — REPLACE your old typing code with this ===== */
 let TYPED_TIMER = null;
 let TYPED_INDEX = 0;
@@ -61,9 +67,11 @@ initTypingForLang(localStorage.getItem('lang') || 'en');
 
 // ========= Theme Toggle =========
 const toggleBtn = document.getElementById('theme-toggle');
+toggleBtn.textContent = document.body.classList.contains('dark') ? '☀️' : '🌙';
 toggleBtn.addEventListener('click', () => {
   document.body.classList.toggle('dark');
   toggleBtn.textContent = document.body.classList.contains('dark') ? '☀️' : '🌙';
+  localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
 });
 
 // ========= Burger Menu =========

--- a/thankyou.html
+++ b/thankyou.html
@@ -78,8 +78,9 @@
   <a href="index.html" class="btn">← Go Back to Portfolio</a>
 
   <script>
-    // Optional: Enable dark mode if body has .dark (from localStorage)
-    if (localStorage.getItem('theme') === 'dark') {
+    // Apply saved theme on page load
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
       document.body.classList.add('dark');
     }
   </script>


### PR DESCRIPTION
## Summary
- Apply previously saved theme on page load
- Persist theme choice using `localStorage` when toggling
- Ensure thankyou page respects saved theme

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_68b9d4981a2c8331829d5833e8a7c402