### PR TITLE
Always show language popup on each visit

### DIFF
--- a/script.js
+++ b/script.js
@@ -228,17 +228,13 @@ arabicBtn.addEventListener('click', () => {
     }
   }
 
-  // First visit? show popup
-  const existing = localStorage.getItem('lang');
-  if (!existing){
-    // Lock background scroll
-    document.body.style.overflow = 'hidden';
-    popup.hidden = false;
-    // trigger entry animation
-    requestAnimationFrame(()=> popup.classList.add('show'));
-    // focus for a11y
-    enBtn.focus();
-  }
+  // Show language selection popup on every visit
+  document.body.style.overflow = 'hidden';
+  popup.hidden = false;
+  // trigger entry animation
+  requestAnimationFrame(() => popup.classList.add('show'));
+  // focus for a11y
+  enBtn.focus();
 
   // Fancy glow follows mouse (optional)
   function handleMove(e){


### PR DESCRIPTION
## Summary
- Always display the language selection popup whenever the site loads, regardless of stored language choice.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ba4e3751988331ba7311ac5a24707f