### PR TITLE
Add language popup heading and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,12 +314,14 @@
 
     <!-- Language Popup (put this just before </body>) -->
     <div id="lang-popup" class="lang-popup" role="dialog" aria-modal="true" aria-labelledby="langPopupHeading" hidden>
+        <h2 id="langPopupHeading">Select Your Language</h2>
+        <p>Choose your preferred language to continue.</p>
         <div class="lang-wrap">
             <!-- English side -->
             <button type="button" class="lang-panel panel-en" id="panel-en" aria-label="Choose English">
                 <div class="panel-inner">
                     <span class="panel-code">EN</span>
-                    <h2 class="panel-title" id="langPopupHeading">English</h2>
+                    <h2 class="panel-title">English</h2>
                     <p class="panel-sub">Modern, professional UI</p>
                 </div>
             </button>

--- a/style.css
+++ b/style.css
@@ -783,6 +783,21 @@ body.dark .lang-toggle {
   display: block;
 }
 
+#lang-popup > h2,
+#lang-popup > p {
+  text-align: center;
+  color: #ffffff;
+}
+
+#lang-popup > h2 {
+  margin-top: 40px;
+  margin-bottom: 8px;
+}
+
+#lang-popup > p {
+  margin-bottom: 24px;
+}
+
 .lang-wrap {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- Add `Select Your Language` heading and description above language panels.
- Remove conflicting id from English panel and ensure popup references new heading.
- Center new heading and paragraph with additional styles.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ba5909823883318d9ea61ed149208a