### PR TITLE
Add close control to language selector popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,6 +314,7 @@
 
     <!-- Language Popup (put this just before </body>) -->
     <div id="lang-popup" class="lang-popup" role="dialog" aria-modal="true" aria-labelledby="langPopupHeading" hidden>
+        <button id="langClose" class="lang-close" aria-label="Close">×</button>
         <div class="lang-wrap">
             <!-- English side -->
             <button type="button" class="lang-panel panel-en" id="panel-en" aria-label="Choose English">

--- a/script.js
+++ b/script.js
@@ -204,6 +204,7 @@ arabicBtn.addEventListener('click', () => {
   const popup = document.getElementById('lang-popup');
   const enBtn = document.getElementById('panel-en');
   const arBtn = document.getElementById('panel-ar');
+  const closeBtn = document.getElementById('langClose');
   if (!popup || !enBtn || !arBtn) return;
 
   // Helper: set lang + html attributes + header toggle reflect
@@ -228,13 +229,15 @@ arabicBtn.addEventListener('click', () => {
     }
   }
 
-  // Show language selection popup on every visit
-  document.body.style.overflow = 'hidden';
-  popup.hidden = false;
-  // trigger entry animation
-  requestAnimationFrame(() => popup.classList.add('show'));
-  // focus for a11y
-  enBtn.focus();
+  // Show language selection popup only if a language hasn't been chosen
+  if (!localStorage.getItem('lang')) {
+    document.body.style.overflow = 'hidden';
+    popup.hidden = false;
+    // trigger entry animation
+    requestAnimationFrame(() => popup.classList.add('show'));
+    // focus for a11y
+    enBtn.focus();
+  }
 
   // Fancy glow follows mouse (optional)
   function handleMove(e){
@@ -246,6 +249,7 @@ arabicBtn.addEventListener('click', () => {
   }
   enBtn.addEventListener('mousemove', handleMove);
   arBtn.addEventListener('mousemove', handleMove);
+  if (closeBtn) closeBtn.addEventListener('click', closePopup);
 
   // Choose EN
   enBtn.addEventListener('click', () => choose('en'));
@@ -269,9 +273,9 @@ arabicBtn.addEventListener('click', () => {
     document.body.style.overflow = ''; // restore scroll
   }
 
-  // Optional: ESC to close only if a language is already set (safety)
+  // Allow ESC to close regardless of language selection
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && localStorage.getItem('lang')) closePopup();
+    if (e.key === 'Escape') closePopup();
   });
 })();
 

--- a/style.css
+++ b/style.css
@@ -783,6 +783,23 @@ body.dark .lang-toggle {
   display: block;
 }
 
+.lang-close {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  width: 44px;
+  height: 44px;
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 10;
+}
+
 .lang-wrap {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- Add close button inside the language selection popup
- Style the close button and allow popup dismissal via click or Escape
- Show the language popup only when no preference is stored

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ba590d67c083318936859e6255941f