### PR TITLE
Remove redundant typing initialization call

### DIFF
--- a/script.js
+++ b/script.js
@@ -42,10 +42,6 @@ function initTypingForLang(lang){
   startTyping();
 }
 
-// প্রথম লোডে লোকালস্টোরেজ দেখে শুরু করুন
-initTypingForLang(localStorage.getItem('lang') || 'en');
-
-
 // // ========= Typing Effect with Pause =========
 // const texts = ["ISLAMIC SCHOLAR", "EDUCATOR", "WRITER", "IT-SKILLED", "DEVELOPER"];
 // let count = 0, index = 0;


### PR DESCRIPTION
## Summary
- Remove standalone `initTypingForLang` invocation so language and typing effect initialize through `window.setLanguage`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ba818f99b08331aa494781cfd273e5