### PR TITLE
Sanitize translation HTML in translation loader

### DIFF
--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,0 +1,10 @@
+# Translation Guidelines
+
+Strings in `i18n/*.json` are sanitized before being injected into the page.
+
+- Plain text is inserted using `textContent`.
+- If basic formatting is needed, only `<strong>`, `<em>` and line breaks `<br>` are allowed.
+- Any other HTML tags or attributes will be stripped for security.
+- Do **not** include scripts, event handlers, or style attributes.
+
+This ensures translators can safely provide emphasis without exposing users to cross-site scripting (XSS) risks.


### PR DESCRIPTION
## Summary
- Sanitize injected translations, using `textContent` for plain strings and whitelisting `<strong>`, `<em>` and `<br>` tags.
- Add translator-facing comments and README detailing sanitization guidelines.

## Testing
- `npm test` *(fails: no package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_b_68ba828854088331ab4e9f7620e669f4