### PR TITLE
Add font setup for Segoe UI and Amiri

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,10 @@
 
     <!-- Favicon -->
     <link rel="icon" href="assets/Favicon.png" type="image/png" />
-    <link rel="stylesheet" href="style.css" />
-    <link href="https://fonts.googleapis.com/css2?family=Segoe+UI:wght@400;600&display=swap" rel="stylesheet" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Amiri&family=Segoe+UI:wght@400;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
 </head>
 
 <body>

--- a/style.css
+++ b/style.css
@@ -22,7 +22,6 @@ body.dark {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
 body {
@@ -30,6 +29,12 @@ body {
   color: var(--text);
   line-height: 1.6;
   scroll-behavior: smooth;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.arabic-text {
+  font-family: 'Amiri', serif;
+  direction: rtl;
 }
 
 a {


### PR DESCRIPTION
## Summary
- load Segoe UI and Amiri fonts from Google Fonts
- default typography uses Segoe UI with `.arabic-text` class for Amiri in RTL sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ba9fb813988331bab2effaa4123e49