### PR TITLE
Initialize Node project with Jest smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/__tests__/pages.test.js
+++ b/__tests__/pages.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('HTML pages', () => {
+  const pages = ['index.html', 'thankyou.html'];
+
+  test.each(pages)('%s contains DOCTYPE', (page) => {
+    const filePath = path.join(__dirname, '..', page);
+    const html = fs.readFileSync(filePath, 'utf8');
+    expect(html).toMatch(/<!DOCTYPE html>/i);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ashiq_elahi_portfolio",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Node.js project and configure Jest
- add smoke tests verifying key HTML pages include DOCTYPE

## Testing
- `npm test` *(fails: jest not found, install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68bc3cde8d088331acc049ecf98a1832