### PR TITLE
Improve CV modal accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,10 +289,10 @@
     </footer>
 
     <!-- CV Download Modal -->
-    <div id="cvModal" class="cv-modal">
+    <div id="cvModal" class="cv-modal" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="cvModalTitle">
         <div class="cv-modal-content">
-            <span class="close-modal">&times;</span>
-            <h2 data-i18n="cv.title">Select CV Language</h2>
+            <button type="button" class="close-modal" aria-label="Close modal">&times;</button>
+            <h2 id="cvModalTitle" data-i18n="cv.title">Select CV Language</h2>
             <button id="downloadEnglish" class="btn" data-i18n="cv.downloadEn">Download English CV</button>
             <button id="downloadArabic" class="btn" data-i18n="cv.downloadAr">Download Arabic CV</button>
         </div>

--- a/script.js
+++ b/script.js
@@ -193,32 +193,76 @@ if (backToTop) {
   const englishBtn = document.getElementById('downloadEnglish');
   const arabicBtn = document.getElementById('downloadArabic');
 
+  let prevFocus = null;
+
   if (!(cvModal && downloadBtn && closeBtn && englishBtn && arabicBtn)) {
     return;
   }
 
-  downloadBtn.addEventListener('click', () => {
+  const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  const getFocusable = () => cvModal.querySelectorAll(focusableSelectors);
+
+  function openModal() {
+    prevFocus = document.activeElement;
     cvModal.style.display = 'block';
+    cvModal.setAttribute('aria-hidden', 'false');
+    const focusables = getFocusable();
+    if (focusables.length > 0) {
+      focusables[0].focus();
+    }
+  }
+
+  function closeModal() {
+    cvModal.style.display = 'none';
+    cvModal.setAttribute('aria-hidden', 'true');
+    if (prevFocus && typeof prevFocus.focus === 'function') {
+      prevFocus.focus();
+    }
+  }
+
+  downloadBtn.addEventListener('click', () => {
+    openModal();
   });
 
   closeBtn.addEventListener('click', () => {
-    cvModal.style.display = 'none';
+    closeModal();
   });
 
   window.addEventListener('click', (e) => {
     if (e.target === cvModal) {
-      cvModal.style.display = 'none';
+      closeModal();
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (cvModal.style.display === 'block') {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeModal();
+      } else if (e.key === 'Tab') {
+        const focusables = getFocusable();
+        if (focusables.length === 0) return;
+        const firstEl = focusables[0];
+        const lastEl = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === firstEl) {
+          e.preventDefault();
+          lastEl.focus();
+        } else if (!e.shiftKey && document.activeElement === lastEl) {
+          e.preventDefault();
+          firstEl.focus();
+        }
+      }
     }
   });
 
   englishBtn.addEventListener('click', () => {
     window.location.href = 'assets/Ashiq_Elahi_CV_IT_and_Digital_Services_Professional.pdf';
-    cvModal.style.display = 'none';
+    closeModal();
   });
 
   arabicBtn.addEventListener('click', () => {
     window.location.href = 'assets/Arabic_Ashiq_Elahi_CV_IT_and_Digital_Services_Professional.pdf';
-    cvModal.style.display = 'none';
+    closeModal();
   });
 })();
 

--- a/style.css
+++ b/style.css
@@ -882,6 +882,10 @@ body.dark .contact-section {
   font-weight: bold;
   color: #333;
   cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  line-height: 1;
 }
 
 /* Dark mode fix: keep modal text visible on white bg */


### PR DESCRIPTION
## Summary
- add ARIA-compliant CV modal markup with close button
- trap focus within modal, restore trigger focus, and allow escape to close

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c16409b7bc83288448bf74cd13aed2