### PR TITLE
fix: remove mobile horizontal overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,6 +41,7 @@ body {
   line-height: 1.6;
   scroll-behavior: smooth;
   font-family: 'Segoe UI', sans-serif;
+  overflow-x: hidden;
 }
 
 .arabic-text {


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling by hiding overflow on the body

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1670f12d08328b2adf6bca432dec6