### PR TITLE
fix: prevent horizontal drag gap on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,6 +35,11 @@ body.dark {
   box-sizing: border-box;
 }
 
+html,
+body {
+  overflow-x: hidden;
+}
+
 body {
   background: var(--bg);
   color: var(--text);
@@ -862,6 +867,7 @@ body.dark .contact-section {
   text-align: center;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
   color: #111827;
+  position: relative;
 }
 
 .cv-modal-content h2 {
@@ -872,6 +878,7 @@ body.dark .contact-section {
   display: block;
   width: 100%;
   margin: 10px 0;
+  box-sizing: border-box;
 }
 
 .close-modal {


### PR DESCRIPTION
## Summary
- hide horizontal overflow on both html and body to stop sideways dragging on mobile
- make CV download modal responsive by containing close button and sizing buttons within the modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1670f12d08328b2adf6bca432dec6